### PR TITLE
Fix flaky test for testSnapshotRestoreSync

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
@@ -649,20 +649,23 @@ class OperatorStateBackendTest {
             assertThat(it).isExhausted();
 
             Iterator<Map.Entry<Serializable, Serializable>> bIt = broadcastState1.iterator();
-            assertThat(bIt).hasNext();
-            Map.Entry<Serializable, Serializable> entry = bIt.next();
-            assertThat(entry.getKey()).isEqualTo(1);
-            assertThat(entry.getValue()).isEqualTo(2);
-
-            assertThat(bIt).hasNext();
-            entry = bIt.next();
-            assertThat(entry.getKey()).isEqualTo(2);
-            assertThat(entry.getValue()).isEqualTo(5);
-            assertThat(bIt).isExhausted();
+            int count = 0;
+            while (bIt.hasNext()) {
+                Map.Entry<Serializable, Serializable> entry = bIt.next();
+                if (entry.getKey().equals(1)) {
+                    assertThat(entry.getValue()).isEqualTo(2);
+                } else if (entry.getKey().equals(2)) {
+                    assertThat(entry.getValue()).isEqualTo(5);
+                } else {
+                    throw new Exception("Unexpected key in broadcast state: " + entry.getKey());
+                }
+                count++;
+            }
+            assertThat(count).isEqualTo(2);
 
             bIt = broadcastState2.iterator();
             assertThat(bIt).hasNext();
-            entry = bIt.next();
+            Map.Entry<Serializable, Serializable> entry = bIt.next();
             assertThat(entry.getKey()).isEqualTo(2);
             assertThat(entry.getValue()).isEqualTo(5);
             assertThat(bIt).isExhausted();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
@@ -649,9 +649,10 @@ class OperatorStateBackendTest {
             assertThat(it).isExhausted();
 
             Iterator<Map.Entry<Serializable, Serializable>> bIt = broadcastState1.iterator();
+            Map.Entry<Serializable, Serializable> entry;
             int count = 0;
             while (bIt.hasNext()) {
-                Map.Entry<Serializable, Serializable> entry = bIt.next();
+                entry = bIt.next();
                 if (entry.getKey().equals(1)) {
                     assertThat(entry.getValue()).isEqualTo(2);
                 } else if (entry.getKey().equals(2)) {
@@ -665,7 +666,7 @@ class OperatorStateBackendTest {
 
             bIt = broadcastState2.iterator();
             assertThat(bIt).hasNext();
-            Map.Entry<Serializable, Serializable> entry = bIt.next();
+            entry = bIt.next();
             assertThat(entry.getKey()).isEqualTo(2);
             assertThat(entry.getValue()).isEqualTo(5);
             assertThat(bIt).isExhausted();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Fix flaky test*


## Brief change log

  - *broadcastState2 is based on Map structure.*
  - *When we put two elements into it, before the change, we assume the first entry we get is the <1, 2> and the second entry is <2, 5> which is not necessary right. So the change makes it independent of the order, just check the element inside the Map, which solves the problem*

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

  - *This change is to fix the test, it changes the test itself*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 

Here is the script for running the non-dex

```
mvn -pl flink-runtime -DnondexRuns=10 edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=org.apache.flink.runtime.state.OperatorStateBackendTest#testSnapshotRestoreSync```
