### PR TITLE
Fix flaky test for CheckpointCoordinatorRestoringTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -77,6 +77,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -103,7 +104,7 @@ public class CheckpointCoordinatorTestingUtils {
             boolean rawState)
             throws IOException {
 
-        Map<String, List<? extends Serializable>> statesListsMap = new HashMap<>(namedStates);
+        Map<String, List<? extends Serializable>> statesListsMap = new LinkedHashMap<>(namedStates);
 
         for (int i = 0; i < namedStates; ++i) {
             List<Integer> testStatesLists = new ArrayList<>(partitionsPerState);
@@ -131,7 +132,7 @@ public class CheckpointCoordinatorTestingUtils {
             boolean rawState)
             throws IOException {
 
-        Map<String, List<? extends Serializable>> statesListsMap = new HashMap<>(namedStates);
+        Map<String, List<? extends Serializable>> statesListsMap = new LinkedHashMap<>(namedStates);
 
         for (int i = 0; i < namedStates; ++i) {
             List<Integer> testStatesLists = new ArrayList<>(partitionsPerState);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Fix flaky test*


## Brief change log

We detected flaky behavior in 

- org.apache.flink.runtime.checkpoint.CheckpointCoordinatorRestoringTest#testRestoreLatestCheckpointedStateWithoutInFlightData
- org.apache.flink.runtime.checkpoint.CheckpointCoordinatorRestoringTest#testStateRecoveryWhenTopologyChangeOut
- org.apache.flink.runtime.checkpoint.CheckpointCoordinatorRestoringTest#testStateRecoveryWhenTopologyChangeIn
- org.apache.flink.runtime.checkpoint.CheckpointCoordinatorRestoringTest#testStateRecoveryWhenTopologyChange
- org.apache.flink.runtime.checkpoint.CheckpointCoordinatorRestoringTest#testRestoreLatestCheckpointedState
- org.apache.flink.runtime.checkpoint.CheckpointCoordinatorRestoringTest#testRestoreLatestCheckpointedStateScaleIn
- org.apache.flink.runtime.checkpoint.CheckpointCoordinatorRestoringTest#testRestoreLatestCheckpointedStateScaleOut


By guarantee the order of generateChainedPartitionableStateHandle and generatePartitionableStateHandle, the flaky problem was resolved 


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

  - *This change is to fix the test, it changes the test itself*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 

Here is the script for running the non-dex

```
mvn -pl flink-runtime -DnondexRuns=10 edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=[your test here]```
