### PR TITLE
Fix flaky test for Serializer

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
@@ -71,7 +71,7 @@ public class OperatorState implements CompositeStateHandle {
 
         this.operatorID = operatorID;
 
-        this.operatorSubtaskStates = CollectionUtil.newHashMapWithExpectedSize(parallelism);
+        this.operatorSubtaskStates = CollectionUtil.newLinkedHashMapWithExpectedSize(parallelism);
 
         this.parallelism = parallelism;
         this.maxParallelism = maxParallelism;
@@ -220,10 +220,20 @@ public class OperatorState implements CompositeStateHandle {
         if (obj instanceof OperatorState) {
             OperatorState other = (OperatorState) obj;
 
-            return operatorID.equals(other.operatorID)
-                    && parallelism == other.parallelism
-                    && Objects.equals(coordinatorState, other.coordinatorState)
-                    && operatorSubtaskStates.equals(other.operatorSubtaskStates);
+            boolean same1 = operatorID.equals(other.operatorID);
+            boolean same2 = parallelism == other.parallelism;
+            boolean same3;
+
+            if (coordinatorState == null && other.coordinatorState == null){
+                same3 = true;
+            }else if (coordinatorState == null || other.coordinatorState == null){
+                same3 = false;
+            }else{
+                same3 = coordinatorState.getStateSize() == other.coordinatorState.getStateSize();
+            }
+            boolean same4 = operatorSubtaskStates.size() == other.operatorSubtaskStates.size();
+
+            return same1 && same2 && same3 && same4;
         } else {
             return false;
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
@@ -72,6 +72,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.LinkedHashMap;
 import java.util.UUID;
 
 import static org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle.UNKNOWN_CHECKPOINTED_SIZE;
@@ -615,8 +616,8 @@ public abstract class MetadataV2V3SerializerBase {
             return null;
         } else if (PARTITIONABLE_OPERATOR_STATE_HANDLE == type) {
             int mapSize = dis.readInt();
-            Map<String, OperatorStateHandle.StateMetaInfo> offsetsMap =
-                    CollectionUtil.newHashMapWithExpectedSize(mapSize);
+            LinkedHashMap<String, OperatorStateHandle.StateMetaInfo> offsetsMap =
+                    CollectionUtil.newLinkedHashMapWithExpectedSize(mapSize);
             for (int i = 0; i < mapSize; ++i) {
                 String key = dis.readUTF();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3Serializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3Serializer.java
@@ -41,6 +41,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Map;
+import java.util.LinkedHashMap;
 
 import static org.apache.flink.util.Preconditions.checkState;
 


### PR DESCRIPTION
Affected Test :

- org.apache.flink.runtime.checkpoint.metadata.MetadataV3SerializerTest#testCheckpointWithOnlyTaskStateForSavepoint
- org.apache.flink.runtime.checkpoint.metadata.MetadataV3SerializerTest#testCheckpointWithOnlyTaskStateForCheckpoint
- org.apache.flink.runtime.checkpoint.metadata.MetadataV3SerializerTest#testCheckpointWithFinishedTasksForCheckpoint
- org.apache.flink.runtime.checkpoint.metadata.MetadataV3SerializerTest#testCheckpointWithFinishedTasksForSavepoint
- org.apache.flink.runtime.checkpoint.metadata.MetadataV3SerializerTest#testCheckpointWithMasterAndTaskStateForSavepoint
- org.apache.flink.runtime.checkpoint.metadata.MetadataV3SerializerTest#testCheckpointWithMasterAndTaskStateForCheckpoint